### PR TITLE
Fix: "축제 진행 여부 보여지는 span태그 css 수정"

### DIFF
--- a/src/main/java/com/multi/FM/fstv/PropertiesReader.java
+++ b/src/main/java/com/multi/FM/fstv/PropertiesReader.java
@@ -1,0 +1,21 @@
+package com.multi.FM.fstv;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+public class PropertiesReader {
+    private static Properties properties;
+
+    static {
+        try (InputStream input = PropertiesReader.class.getClassLoader().getResourceAsStream("db.properties")) {
+            properties = new Properties();
+            properties.load(input);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static String getProperty(String key) {
+        return properties.getProperty(key);
+    }
+}

--- a/src/main/resources/mapper/festival.xml
+++ b/src/main/resources/mapper/festival.xml
@@ -91,7 +91,7 @@
 				b.booth_category, b.booth_image
 		from booth b
 		left join review r on b.booth_no = r.booth_no
-		where b.fstv_no = #{fstv_no}
+		where b.fstv_no = #{fstv_no} and booth_ban = 0
 		group by b.booth_no, b.booth_name, b.booth_category, b.booth_image
 		order by b.booth_no
 	</select>
@@ -103,7 +103,7 @@
 				b.booth_category, b.booth_image 
 		from booth b
 		left join review r on b.booth_no = r.booth_no 
-		where b.fstv_no = #{fstv_no}
+		where b.fstv_no = #{fstv_no} and booth_ban = 0
 		group by b.booth_no, b.booth_name, b.booth_category, b.booth_image 
 		order by booth_starpoint desc
 	</select>
@@ -171,6 +171,7 @@
 		from booth b
 		join review r on b.booth_no = r.booth_no
 		join festival f on b.fstv_no = f.fstv_no
+		where booth_ban = 0
 		group by f.fstv_title, b.booth_no, b.booth_name, b.booth_introduction
 		order by review_cnt desc limit 4
 	</select>

--- a/src/main/webapp/WEB-INF/views/fstv/fstv_detail.jsp
+++ b/src/main/webapp/WEB-INF/views/fstv/fstv_detail.jsp
@@ -1,3 +1,4 @@
+<%@page import="com.multi.FM.fstv.PropertiesReader"%>
 <%@page import="org.apache.ibatis.reflection.SystemMetaObject"%>
 <%@page import="com.multi.FM.fstv.FestivalVO"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
@@ -5,6 +6,7 @@
 <%	
 	FestivalVO vo = (FestivalVO)request.getAttribute("vo");
 	String id = (String)session.getAttribute("id");
+	String apiKey = PropertiesReader.getProperty("map.apiKey");
 %>
 <!DOCTYPE html>
 <html lang="en">
@@ -14,7 +16,7 @@
     <title>모든 축제의 부스를 담다 - 부스락</title>
 	<link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/fstv_detail.css" type="text/css">
 	<script type="text/javascript"
-		src="//dapi.kakao.com/v2/maps/sdk.js?appkey=APPkey"></script>
+		src="//dapi.kakao.com/v2/maps/sdk.js?appkey=<%=apiKey%>"></script>
 	<script src="${pageContext.request.contextPath}/resources/js/fstv_detail.js" defer type="text/javascript"></script>
 </head>
 <body>
@@ -81,7 +83,10 @@
 	        		</h3>
 	        	
 	        		<div id="map" class="fstv-map">
-	        			<a class="route-finder" href="https://map.kakao.com/link/to/' + title + ',' + lat + ',' + lng + '" target="_blank"><i class="fa-solid fa-location-arrow"></i> 길찾기</a>
+	        			<a class="route-finder"
+	        			href="https://map.kakao.com/link/to/<%=vo.getFstv_title()%>,<%=vo.getFstv_mapy()%>,<%=vo.getFstv_mapx()%>"
+	        			target="_blank">
+	        			<i class="fa-solid fa-location-arrow"></i> 길찾기</a>
 	        		</div>
 	        		<!-- <div class="fstv-map">
 	        			<img alt="카카오맵" src="resources/img/카카오맵.png">
@@ -118,7 +123,7 @@
 
 		var map = new kakao.maps.Map(mapContainer, mapOption);
 		
-		var imageSrc = 'resources/img/marker.png', // 마커이미지의 주소입니다    
+		var imageSrc = '${pageContext.request.contextPath}/resources/img/marker.png', // 마커이미지의 주소입니다    
 		    imageSize = new kakao.maps.Size(35, 38), // 마커이미지의 크기입니다
 		    imageOption = {offset: new kakao.maps.Point(18, 40)}; // 마커이미지의 옵션입니다. 마커의 좌표와 일치시킬 이미지 안에서의 좌표를 설정합니다.
 	    
@@ -136,12 +141,11 @@
 		marker.setMap(map);  
 
 		// 커스텀 오버레이에 표출될 내용으로 HTML 문자열이나 document element가 가능합니다
-		var content = '<div class="customoverlay">' +
-		    '  <a class="title-finder" href="https://map.kakao.com/link/to/' + title + ',' + lat + ',' + lng + '" target="_blank">' +
+		var content = '<div class="customoverlay">'+'<a class="title-finder" href="https://map.kakao.com/link/to/'+ title +','+lat+','+lng+'" target="_blank">' +
 		    '    <span class="title">' + title + '</span>' +
 		    '  </a>' +
 		    '</div>';
-
+		console.log(title);
 		// 커스텀 오버레이가 표시될 위치입니다 
 		var position = new kakao.maps.LatLng(lat, lng);  
 

--- a/src/main/webapp/WEB-INF/views/fstv/fstv_search.jsp
+++ b/src/main/webapp/WEB-INF/views/fstv/fstv_search.jsp
@@ -6,6 +6,8 @@
     pageEncoding="UTF-8"%>
 <% 
   	String q = (String)request.getAttribute("q");
+	List<FestivalVO> lists = (List<FestivalVO>)request.getAttribute("list");
+	int cnt = lists.size();
 %>
 <!DOCTYPE html>
 <html lang="en">
@@ -34,6 +36,11 @@
 	    <div class="search-form">
 	    	<div class="search-head">
 	    		<h1>'${q}'</h1>
+	    		<% if(cnt == 0) { %>
+	    		<h2>검색 결과가 없습니다 <i class="fa-solid fa-magnifying-glass"></i></h2>
+	    	</div>
+	    	<img src="https://boothrockstorage.s3.ap-northeast-2.amazonaws.com/992ba1ca-afad-4510-8f0c-6ca05531b6bb" class="no-search">
+    			<% } else {%>
 	    		<h2>검색 결과 <i class="fa-solid fa-magnifying-glass"></i></h2>
 	    	</div>
 	         <div class="search-fstv-list">
@@ -67,6 +74,7 @@
 					</c:forEach>
 				</ul>
 	        </div>
+    			<% } %>
 	    </div>
     </div>
 	

--- a/src/main/webapp/fstv_map.jsp
+++ b/src/main/webapp/fstv_map.jsp
@@ -204,6 +204,7 @@
 						success : function(list) {
 							$('.fstv-list').html(list);
 							append_date();
+							scroll_to_top();
 						}
 					})
 					
@@ -223,6 +224,12 @@
 		function append_date() {
 		    $('li.fstv-end').append('<div class="fstv-end-text">축제종료</div>');
 		    $('li.fstv-will').append('<div class="fstv-will-text">개최예정</div>');
+		}
+		function scroll_to_top() {
+		    window.scrollTo({
+		        top: 0,
+		        behavior: 'smooth'
+		    });
 		}
 	</script>
 </body>

--- a/src/main/webapp/fstv_map.jsp
+++ b/src/main/webapp/fstv_map.jsp
@@ -1,5 +1,9 @@
+<%@page import="com.multi.FM.fstv.PropertiesReader"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
+<%
+	String apiKey = PropertiesReader.getProperty("map.apiKey");
+%>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -8,7 +12,7 @@
     <title>모든 축제의 부스를 담다 - 부스락</title>
     <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/fstv_map.css" type="text/css">
     <script src="${pageContext.request.contextPath}/resources/js/fstv_map.js" defer type="text/javascript"></script>
-	<script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=f555a223b0daef77d257c80c6f4e9ab0"></script>
+	<script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=<%=apiKey%>"></script>
 </head>
 <body>
     <%@ include file="header.jsp" %>

--- a/src/main/webapp/resources/css/fstv_list.css
+++ b/src/main/webapp/resources/css/fstv_list.css
@@ -100,7 +100,7 @@
     left: 0px;
     background-color: #876ed5;
     padding: 5px;
-    border-radius: 5px;
+    border-radius: 10px 5px 5px 5px;
     font-weight: bold;
     color: #fff;
 }
@@ -110,6 +110,6 @@
     left: 0px;
     background-color: #bffd9f;
     padding: 5px;
-    border-radius: 5px;
+    border-radius: 10px 5px 5px 5px;
     font-weight: bold;
 }

--- a/src/main/webapp/resources/css/fstv_search.css
+++ b/src/main/webapp/resources/css/fstv_search.css
@@ -115,3 +115,8 @@
     border-radius: 10px 5px 5px 5px;
     font-weight: bold;
 }
+.no-search {
+    opacity: 0.5;
+    width: 500px;
+    margin: 20px 280px;
+}

--- a/src/main/webapp/resources/css/fstv_search.css
+++ b/src/main/webapp/resources/css/fstv_search.css
@@ -102,7 +102,7 @@
     left: 0px;
     background-color: #876ed5;
     padding: 5px;
-    border-radius: 5px;
+    border-radius: 10px 5px 5px 5px;
     font-weight: bold;
     color: #fff;
 }
@@ -112,6 +112,6 @@
     left: 0px;
     background-color: #bffd9f;
     padding: 5px;
-    border-radius: 5px;
+    border-radius: 10px 5px 5px 5px;
     font-weight: bold;
 }


### PR DESCRIPTION
Fix: "축제 진행 여부 보여지는 span태그 css 수정"
Fix: "booth_ban가 0인 부스만 가져오도록 수정"
Fix: "fstv_search 검색결과 없을 때 결과창 수정"
Add: "전국축제지도 마커 클릭 시 스크롤 초기화 적용"
Feat: "kakao API Key 분리 구현"